### PR TITLE
Use namespaced exceptions instead of raising Exception in socket_client.rb

### DIFF
--- a/lib/deathbycaptcha/errors.rb
+++ b/lib/deathbycaptcha/errors.rb
@@ -64,6 +64,30 @@ module DeathByCaptcha
       end
     end
 
+    #
+    # Raised when the connection times out.
+    #
+    class Timeout < Error
+    end
+
+    #
+    # Raised when there's an invalid API response.
+    #
+    class InvalidApiResponse < Error
+      def initialize
+        super('Invalid API response')
+      end
+    end
+
+    #
+    # Raised when an API server error occurred
+    #
+    class ApiServerError < Error
+      def initialize
+        super('API server error occured')
+      end
+    end
+
   end
 
 end

--- a/lib/deathbycaptcha/socket_client.rb
+++ b/lib/deathbycaptcha/socket_client.rb
@@ -194,7 +194,7 @@ module DeathByCaptcha
         msg = 'Connection timed out during API request'
         log('SEND', msg)
 
-        raise DeathByCaptcha::Errors::Timeout, msg
+        raise DeathByCaptcha::Errors::Timeout.new(msg)
       end
 
       log('RECV', response.to_s)

--- a/lib/deathbycaptcha/socket_client.rb
+++ b/lib/deathbycaptcha/socket_client.rb
@@ -194,7 +194,7 @@ module DeathByCaptcha
         msg = 'Connection timed out during API request'
         log('SEND', msg)
 
-        raise Exception.new(msg)
+        raise DeathByCaptcha::Errors::Timeout, msg
       end
 
       log('RECV', response.to_s)
@@ -202,13 +202,13 @@ module DeathByCaptcha
       begin
         response = JSON.load(response)
       rescue Exception => e
-        raise Exception.new('Invalid API response')
+        raise DeathByCaptcha::Errors::InvalidApiResponse
       end
 
       if 0x00 < response['status'] and 0x10 > response['status']
         raise DeathByCaptcha::Errors::AccessDenied
       elsif 0xff == response['status']
-        raise Exception.new('API server error occured')
+        raise DeathByCaptcha::Errors::ApiServerError
       else
         return response
       end

--- a/lib/deathbycaptcha/version.rb
+++ b/lib/deathbycaptcha/version.rb
@@ -1,4 +1,4 @@
 module DeathByCaptcha
-  VERSION = "4.1.5"
+  VERSION = "4.1.6"
   API_VERSION = "DBC/Ruby v4.1.2"
 end


### PR DESCRIPTION
socket_client.rb has 3 locations where it raises Exception instead of some custom class derived from StandardError.  This poses problems if clients of this gem have `begin...except` clauses that expect a StandardError.

I couldn't find any rspec tests for this gem and the conditions in which these exceptions would be raised are intermittent, so I haven't been able to do integration tests either.