### PR TITLE
Allow custom HTTP Client hostname

### DIFF
--- a/lib/deathbycaptcha/client.rb
+++ b/lib/deathbycaptcha/client.rb
@@ -12,7 +12,7 @@ module DeathByCaptcha
   #
   class Client
 
-    attr_accessor :username, :password, :timeout, :polling
+    attr_accessor :username, :password, :timeout, :polling, :hostname
 
     # Create a DeathByCaptcha API client
     #
@@ -51,6 +51,7 @@ module DeathByCaptcha
       self.password   = password
       self.timeout    = options[:timeout] || 60
       self.polling    = options[:polling] || 5
+      self.hostname   = ENV.fetch('DBC_HOSTNAME', 'api.dbcapi.me')
     end
 
     # Decode the text from an image (i.e. solve a captcha).

--- a/lib/deathbycaptcha/client/http.rb
+++ b/lib/deathbycaptcha/client/http.rb
@@ -3,9 +3,6 @@ module DeathByCaptcha
   # HTTP client for DeathByCaptcha API.
   #
   class Client::HTTP < Client
-
-    BASE_URL = 'http://api.dbcapi.me/api'
-
     # Retrieve information from an uploaded captcha.
     #
     # @param [Integer] captcha_id Numeric ID of the captcha.
@@ -86,18 +83,18 @@ module DeathByCaptcha
       headers = { 'User-Agent' => DeathByCaptcha::API_VERSION }
 
       if method == :post
-        uri = URI("#{BASE_URL}/#{action}")
+        uri = URI("http://#{self.hostname}/api/#{action}")
         req = Net::HTTP::Post.new(uri.request_uri, headers)
         req.set_form_data(payload)
 
       elsif method == :post_multipart
-        uri = URI("#{BASE_URL}/#{action}")
+        uri = URI("http://#{self.hostname}/api/#{action}")
         req = Net::HTTP::Post.new(uri.request_uri, headers)
         boundary, body = prepare_multipart_data(payload)
         req.content_type = "multipart/form-data; boundary=#{boundary}"
         req.body = body
       else
-        uri = URI("#{BASE_URL}/#{action}?#{URI.encode_www_form(payload)}")
+        uri = URI("http://#{self.hostname}/api/#{action}?#{URI.encode_www_form(payload)}")
         req = Net::HTTP::Get.new(uri.request_uri, headers)
       end
 

--- a/lib/deathbycaptcha/client/socket.rb
+++ b/lib/deathbycaptcha/client/socket.rb
@@ -4,7 +4,6 @@ module DeathByCaptcha
   #
   class Client::Socket < Client
 
-    HOST  = 'api.dbcapi.me'
     PORTS = (8123..8130).to_a
 
     # Retrieve information from an uploaded captcha.
@@ -116,7 +115,7 @@ module DeathByCaptcha
     #
     def create_socket
       socket = ::Socket.new(::Socket::AF_INET, ::Socket::SOCK_STREAM, 0)
-      sockaddr = ::Socket.sockaddr_in(PORTS.sample, HOST)
+      sockaddr = ::Socket.sockaddr_in(PORTS.sample, self.hostname)
       begin # emulate blocking connect
         socket.connect_nonblock(sockaddr)
       rescue IO::WaitWritable


### PR DESCRIPTION
Spoke with DBC support today about an issue with the API - they suggested using an alternate API endpoint, so this enables me to do so.
