### PR TITLE
require openssl as dependency

### DIFF
--- a/lib/deathbycaptcha.rb
+++ b/lib/deathbycaptcha.rb
@@ -1,4 +1,5 @@
 require 'base64'
+require 'openssl'
 require 'json'
 require 'bigdecimal'
 require 'socket'


### PR DESCRIPTION
when the decode! method is called, with the :url option using the https protocol an "unitialized constant OpenSSL" exception will be raised (some captchas use the https protocol).  As all the errors are rescued and re-raised as an InvalidCaptcha error, the user will be totally unaware about the root of this exception 
(line 163 -> 179 deathbycaptch/client.rb -> load_captcha method)

Anyway, the require 'openssl' should solve the issue.

BTW, keep up the good work